### PR TITLE
Add pgxdb and envelope packages (pgx pool, fail-closed RLS, KEK/DEK encryption)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.1
 
 require (
 	github.com/cucumber/godog v0.15.1
+	github.com/cucumber/messages/go/v21 v21.0.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
@@ -11,6 +12,8 @@ require (
 	github.com/go-redsync/redsync/v4 v4.15.0
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.25.1
+	github.com/jackc/pgx/v5 v5.10.0
+	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/redis/go-redis/v9 v9.17.2
 	github.com/stretchr/testify v1.11.1
@@ -23,7 +26,6 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
-	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
@@ -35,11 +37,9 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.6 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/pkg/envelope/envelope_test.go
+++ b/pkg/envelope/envelope_test.go
@@ -1,0 +1,200 @@
+package envelope_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+
+	"github.com/sousair/gocore/pkg/envelope"
+)
+
+// newKEKEnv returns a base64-encoded random 32-byte key suitable for use as
+// an env-var KEK and sets it on the named env var for the duration of the test.
+func newKEKEnv(t *testing.T, envVar string) {
+	t.Helper()
+	kek := make([]byte, 32)
+	if _, err := rand.Read(kek); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envVar, base64.StdEncoding.EncodeToString(kek))
+}
+
+// --- EnvKEKProvider tests ---
+
+func TestEnvKEKProvider(t *testing.T) {
+	const envVar = "GOCORE_TEST_KEK"
+
+	t.Run("given a valid env KEK/when a DEK is wrapped and unwrapped/then the roundtrip is lossless", func(t *testing.T) {
+		newKEKEnv(t, envVar)
+		p, err := envelope.NewEnvKEKProvider(envVar)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dek := []byte("0123456789abcdef0123456789abcdef")
+		wrapped, err := p.WrapDEK(dek)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := p.UnwrapDEK(wrapped)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, dek) {
+			t.Errorf("roundtrip mismatch: got %x, want %x", got, dek)
+		}
+	})
+
+	t.Run("given a wrapped DEK/when the ciphertext is tampered/then unwrap fails", func(t *testing.T) {
+		newKEKEnv(t, envVar)
+		p, _ := envelope.NewEnvKEKProvider(envVar)
+		wrapped, _ := p.WrapDEK([]byte("0123456789abcdef0123456789abcdef"))
+		wrapped[len(wrapped)-1] ^= 0xFF
+		if _, err := p.UnwrapDEK(wrapped); err == nil {
+			t.Error("want error on tampered ciphertext, got nil")
+		}
+	})
+
+	t.Run("given the env var is unset/when the provider is constructed/then it errors", func(t *testing.T) {
+		t.Setenv(envVar, "")
+		if _, err := envelope.NewEnvKEKProvider(envVar); err == nil {
+			t.Error("want error for unset env var, got nil")
+		}
+	})
+
+	t.Run("given the env var is not base64/when the provider is constructed/then it errors", func(t *testing.T) {
+		t.Setenv(envVar, "not-base64!!!")
+		if _, err := envelope.NewEnvKEKProvider(envVar); err == nil {
+			t.Error("want error for non-base64 env var, got nil")
+		}
+	})
+
+	t.Run("given the env var decodes to the wrong length/when the provider is constructed/then it errors", func(t *testing.T) {
+		t.Setenv(envVar, base64.StdEncoding.EncodeToString(make([]byte, 16)))
+		if _, err := envelope.NewEnvKEKProvider(envVar); err == nil {
+			t.Error("want error for 16-byte KEK, got nil")
+		}
+	})
+}
+
+// --- FieldCipher tests ---
+
+func TestFieldCipher(t *testing.T) {
+	t.Run("given a DEK/when a field value is encrypted and decrypted/then the roundtrip is lossless", func(t *testing.T) {
+		dek := make([]byte, 32)
+		if _, err := rand.Read(dek); err != nil {
+			t.Fatal(err)
+		}
+		fc, err := envelope.NewFieldCipher(dek)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ct, err := fc.Encrypt([]byte("rendimento do FII em janeiro"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		pt, err := fc.Decrypt(ct)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(pt) != "rendimento do FII em janeiro" {
+			t.Errorf("roundtrip mismatch: %q", pt)
+		}
+	})
+
+	t.Run("given a DEK that is not 32 bytes/when the field cipher is constructed/then it errors", func(t *testing.T) {
+		if _, err := envelope.NewFieldCipher(make([]byte, 16)); err == nil {
+			t.Error("want error for 16-byte DEK, got nil")
+		}
+	})
+
+	// --- AAD tests ---
+
+	t.Run("given matching AAD/when encrypt then decrypt with same AAD/then roundtrip succeeds", func(t *testing.T) {
+		dek := make([]byte, 32)
+		if _, err := rand.Read(dek); err != nil {
+			t.Fatal(err)
+		}
+		fc, err := envelope.NewFieldCipher(dek)
+		if err != nil {
+			t.Fatal(err)
+		}
+		aad := []byte("record-id:abc123 field:salary")
+		ct, err := fc.Encrypt([]byte("secret value"), envelope.WithAAD(aad))
+		if err != nil {
+			t.Fatal(err)
+		}
+		pt, err := fc.Decrypt(ct, envelope.WithAAD(aad))
+		if err != nil {
+			t.Fatalf("decrypt with matching AAD failed: %v", err)
+		}
+		if string(pt) != "secret value" {
+			t.Errorf("roundtrip mismatch: %q", pt)
+		}
+	})
+
+	t.Run("given mismatched AAD/when decrypt is called with different AAD/then it fails", func(t *testing.T) {
+		dek := make([]byte, 32)
+		if _, err := rand.Read(dek); err != nil {
+			t.Fatal(err)
+		}
+		fc, _ := envelope.NewFieldCipher(dek)
+		ct, _ := fc.Encrypt([]byte("secret"), envelope.WithAAD([]byte("record-id:abc123")))
+		if _, err := fc.Decrypt(ct, envelope.WithAAD([]byte("record-id:DIFFERENT"))); err == nil {
+			t.Error("want error when AAD differs, got nil")
+		}
+	})
+
+	t.Run("given AAD used at encrypt/when decrypt is called without AAD/then it fails", func(t *testing.T) {
+		dek := make([]byte, 32)
+		if _, err := rand.Read(dek); err != nil {
+			t.Fatal(err)
+		}
+		fc, _ := envelope.NewFieldCipher(dek)
+		ct, _ := fc.Encrypt([]byte("secret"), envelope.WithAAD([]byte("context")))
+		if _, err := fc.Decrypt(ct); err == nil {
+			t.Error("want error when AAD omitted but was used at encrypt, got nil")
+		}
+	})
+}
+
+// --- KEKProvider AAD tests ---
+
+func TestEnvKEKProvider_AAD(t *testing.T) {
+	const envVar = "GOCORE_TEST_KEK_AAD"
+
+	t.Run("given matching AAD/when WrapDEK then UnwrapDEK with same AAD/then roundtrip succeeds", func(t *testing.T) {
+		newKEKEnv(t, envVar)
+		p, err := envelope.NewEnvKEKProvider(envVar)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dek := make([]byte, 32)
+		if _, err := rand.Read(dek); err != nil {
+			t.Fatal(err)
+		}
+		aad := []byte("dek-id:xyz field:ssn")
+		wrapped, err := p.WrapDEK(dek, envelope.WithAAD(aad))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := p.UnwrapDEK(wrapped, envelope.WithAAD(aad))
+		if err != nil {
+			t.Fatalf("unwrap with matching AAD failed: %v", err)
+		}
+		if !bytes.Equal(got, dek) {
+			t.Errorf("roundtrip mismatch")
+		}
+	})
+
+	t.Run("given AAD used at wrap/when unwrap is called with different AAD/then it fails", func(t *testing.T) {
+		newKEKEnv(t, envVar)
+		p, _ := envelope.NewEnvKEKProvider(envVar)
+		dek := make([]byte, 32)
+		rand.Read(dek) //nolint:errcheck
+		wrapped, _ := p.WrapDEK(dek, envelope.WithAAD([]byte("original-context")))
+		if _, err := p.UnwrapDEK(wrapped, envelope.WithAAD([]byte("tampered-context"))); err == nil {
+			t.Error("want error when AAD differs, got nil")
+		}
+	})
+}

--- a/pkg/envelope/field.go
+++ b/pkg/envelope/field.go
@@ -1,0 +1,38 @@
+package envelope
+
+import (
+	gocipher "crypto/cipher"
+	"fmt"
+)
+
+// FieldCipher encrypts and decrypts individual field values using a DEK
+// (data-encryption key). The DEK must be exactly 32 bytes (AES-256-GCM).
+type FieldCipher struct{ aead gocipher.AEAD }
+
+// NewFieldCipher constructs a FieldCipher from a 32-byte DEK. Returns an
+// error if the DEK is not exactly 32 bytes.
+func NewFieldCipher(dek []byte) (*FieldCipher, error) {
+	if len(dek) != 32 {
+		return nil, fmt.Errorf("envelope: DEK must be 32 bytes for AES-256-GCM, got %d", len(dek))
+	}
+	aead, err := newAEAD(dek)
+	if err != nil {
+		return nil, err
+	}
+	return &FieldCipher{aead: aead}, nil
+}
+
+// Encrypt encrypts plaintext using AES-256-GCM. A random nonce is prepended
+// to the ciphertext. The optional WithAAD option binds the ciphertext to a
+// context; Decrypt must receive the same AAD.
+func (f *FieldCipher) Encrypt(plaintext []byte, opts ...Option) ([]byte, error) {
+	o := applyOptions(opts)
+	return seal(f.aead, plaintext, o.aad)
+}
+
+// Decrypt decrypts a ciphertext produced by Encrypt. The AAD passed here must
+// match the AAD used during Encrypt, or decryption will fail.
+func (f *FieldCipher) Decrypt(ciphertext []byte, opts ...Option) ([]byte, error) {
+	o := applyOptions(opts)
+	return open(f.aead, ciphertext, o.aad)
+}

--- a/pkg/envelope/kek.go
+++ b/pkg/envelope/kek.go
@@ -1,0 +1,129 @@
+// Package envelope implements ADR-012 envelope encryption: each field value is
+// encrypted with a per-record DEK (AES-256-GCM); DEKs are wrapped by a KEK
+// held by a KEKProvider. The v0 provider reads the KEK from an environment
+// variable; future providers (e.g. OpenBao-backed) satisfy the same interface
+// with zero call-site changes.
+//
+// # AAD (Additional Authenticated Data)
+//
+// Both KEKProvider and FieldCipher accept a WithAAD option that binds the
+// ciphertext to contextual identity (e.g. record ID + field name). Decryption
+// must present the identical AAD or fail. This prevents a ciphertext from
+// being replayed into a different field or record without detection.
+package envelope
+
+import (
+	"crypto/aes"
+	gocipher "crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// options holds functional-option state shared by KEKProvider and FieldCipher
+// operations.
+type options struct {
+	aad []byte
+}
+
+// Option configures encryption or decryption behaviour.
+type Option func(*options)
+
+// WithAAD binds the ciphertext to contextual identity (e.g. a record ID or
+// field name). Decryption must present the same AAD or the AEAD open will
+// fail. Passing nil or omitting the option uses no AAD.
+func WithAAD(aad []byte) Option {
+	return func(o *options) {
+		o.aad = aad
+	}
+}
+
+func applyOptions(opts []Option) *options {
+	o := &options{}
+	for _, fn := range opts {
+		fn(o)
+	}
+	return o
+}
+
+// KEKProvider wraps and unwraps DEKs using a Key Encryption Key.
+type KEKProvider interface {
+	// WrapDEK encrypts dek with the KEK. The optional WithAAD option binds the
+	// wrapped ciphertext to a context; UnwrapDEK must receive the same AAD.
+	WrapDEK(dek []byte, opts ...Option) ([]byte, error)
+
+	// UnwrapDEK decrypts a previously wrapped DEK. The AAD passed here must
+	// match the AAD used during WrapDEK, or decryption will fail.
+	UnwrapDEK(wrapped []byte, opts ...Option) ([]byte, error)
+}
+
+type envKEKProvider struct{ aead gocipher.AEAD }
+
+// NewEnvKEKProvider constructs a KEKProvider whose KEK is read from the
+// environment variable named by envVar. The value must be a base64-encoded
+// 32-byte key (AES-256). Returns an error if envVar is unset, not valid
+// base64, or not exactly 32 bytes after decoding.
+func NewEnvKEKProvider(envVar string) (KEKProvider, error) {
+	raw := os.Getenv(envVar)
+	if raw == "" {
+		return nil, fmt.Errorf("envelope: %s is unset", envVar)
+	}
+	kek, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("envelope: %s is not valid base64: %w", envVar, err)
+	}
+	if len(kek) != 32 {
+		return nil, fmt.Errorf("envelope: %s must decode to 32 bytes for AES-256, got %d", envVar, len(kek))
+	}
+	aead, err := newAEAD(kek)
+	if err != nil {
+		return nil, err
+	}
+	return &envKEKProvider{aead: aead}, nil
+}
+
+func (p *envKEKProvider) WrapDEK(dek []byte, opts ...Option) ([]byte, error) {
+	o := applyOptions(opts)
+	return seal(p.aead, dek, o.aad)
+}
+
+func (p *envKEKProvider) UnwrapDEK(wrapped []byte, opts ...Option) ([]byte, error) {
+	o := applyOptions(opts)
+	return open(p.aead, wrapped, o.aad)
+}
+
+// newAEAD creates an AES-256-GCM AEAD from a 32-byte key.
+func newAEAD(key []byte) (gocipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("envelope: %w", err)
+	}
+	return gocipher.NewGCM(block)
+}
+
+// seal encrypts plaintext with aad as additional authenticated data. The
+// random nonce is prepended to the ciphertext so the result is self-contained.
+func seal(aead gocipher.AEAD, plaintext, aad []byte) ([]byte, error) {
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("envelope: nonce: %w", err)
+	}
+	return aead.Seal(nonce, nonce, plaintext, aad), nil
+}
+
+// open decrypts a sealed value produced by seal. aad must match what was
+// passed to seal, or decryption will fail.
+func open(aead gocipher.AEAD, sealed, aad []byte) ([]byte, error) {
+	if len(sealed) < aead.NonceSize() {
+		return nil, errors.New("envelope: sealed value too short")
+	}
+	nonce, ct := sealed[:aead.NonceSize()], sealed[aead.NonceSize():]
+	pt, err := aead.Open(nil, nonce, ct, aad)
+	if err != nil {
+		return nil, fmt.Errorf("envelope: open: %w", err)
+	}
+	return pt, nil
+}

--- a/pkg/pgxdb/pgxdb_test.go
+++ b/pkg/pgxdb/pgxdb_test.go
@@ -1,0 +1,163 @@
+package pgxdb_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sousair/gocore/pkg/pgxdb"
+)
+
+// testPool connects to the DSN in GOCORE_PGX_TEST_DSN.
+// The DSN user must be able to CREATE TABLE, ALTER TABLE, and ENABLE ROW LEVEL
+// SECURITY (i.e. the table owner or a superuser). In local dev the postgres
+// superuser satisfies this; in CI use a dedicated test role with CREATEDB.
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("GOCORE_PGX_TEST_DSN")
+	if dsn == "" {
+		t.Skip("GOCORE_PGX_TEST_DSN unset — set it to run integration tests")
+	}
+	pool, err := pgxdb.NewPool(context.Background(), dsn)
+	if err != nil {
+		t.Skipf("GOCORE_PGX_TEST_DSN set but unreachable (%v) — check that the DB is running", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// TestRLS_WithGUC is a unit test; it needs no database.
+func TestRLS_WithGUC(t *testing.T) {
+	t.Run("given a nil pool/when NewRLS constructs with defaults/then it returns a usable value", func(t *testing.T) {
+		pool := (*pgxpool.Pool)(nil) // intentionally nil — not used in this subtest
+		r := pgxdb.NewRLS(pool)
+		if r == nil {
+			t.Fatal("NewRLS returned nil")
+		}
+	})
+
+	t.Run("given a nil pool/when InUserTx is called/then it returns an error not a panic", func(t *testing.T) {
+		r := pgxdb.NewRLS((*pgxpool.Pool)(nil))
+		err := r.InUserTx(context.Background(), uuid.New(), func(pgx.Tx) error { return nil })
+		if err == nil {
+			t.Fatal("expected error for nil pool, got nil")
+		}
+	})
+
+	t.Run("given WithGUC option/when NewRLS is called/then the option is applied without error", func(t *testing.T) {
+		pool := (*pgxpool.Pool)(nil)
+		r := pgxdb.NewRLS(pool, pgxdb.WithGUC("my.user_id"))
+		if r == nil {
+			t.Fatal("NewRLS returned nil with WithGUC option")
+		}
+	})
+}
+
+// TestRLS_FailClosedPolicy is an integration test gated by GOCORE_PGX_TEST_DSN.
+//
+// It creates a temporary table with the recommended fail-closed NULLIF RLS
+// policy, seeds two rows (one per user), and verifies the three RLS scenarios:
+// own-row visible, cross-user row invisible, no-context returns zero rows.
+//
+// NOTE: FORCE ROW LEVEL SECURITY is set so that the table owner (the test DSN
+// user) is also subject to the policy. Without FORCE, the owner bypasses RLS
+// and all three subtests would pass trivially for the wrong reason.
+func TestRLS_FailClosedPolicy(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	rls := pgxdb.NewRLS(pool)
+
+	// Use a unique table name so parallel test runs don't collide.
+	table := fmt.Sprintf("pgxdb_rls_test_%s", uuid.New().String()[:8])
+
+	// Setup: create a minimal table with the fail-closed RLS policy.
+	setup := fmt.Sprintf(`
+		CREATE TABLE %s (
+			id   uuid PRIMARY KEY,
+			owner_id uuid NOT NULL
+		);
+		ALTER TABLE %s ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE %s FORCE ROW LEVEL SECURITY;
+		CREATE POLICY select_own ON %s
+			FOR SELECT
+			USING (owner_id = NULLIF(current_setting('app.current_user_id', true), '')::uuid);
+	`, table, table, table, table)
+
+	if _, err := pool.Exec(ctx, setup); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	t.Cleanup(func() {
+		pool.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", table)) //nolint:errcheck
+	})
+
+	alice, bob := uuid.New(), uuid.New()
+
+	// Seed one row per user.
+	for _, id := range []uuid.UUID{alice, bob} {
+		err := rls.InUserTx(ctx, id, func(tx pgx.Tx) error {
+			_, err := tx.Exec(ctx,
+				fmt.Sprintf("INSERT INTO %s (id, owner_id) VALUES ($1, $2)", table),
+				id, id,
+			)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	t.Run("given alice's row exists/when alice reads it/then it is visible", func(t *testing.T) {
+		err := rls.InUserTx(ctx, alice, func(tx pgx.Tx) error {
+			var got uuid.UUID
+			row := tx.QueryRow(ctx,
+				fmt.Sprintf("SELECT id FROM %s WHERE id = $1", table), alice)
+			if err := row.Scan(&got); err != nil {
+				return err
+			}
+			if got != alice {
+				t.Errorf("got %s, want %s", got, alice)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("read own row: %v", err)
+		}
+	})
+
+	t.Run("given alice's row exists/when bob reads it/then it is invisible", func(t *testing.T) {
+		err := rls.InUserTx(ctx, bob, func(tx pgx.Tx) error {
+			var got uuid.UUID
+			row := tx.QueryRow(ctx,
+				fmt.Sprintf("SELECT id FROM %s WHERE id = $1", table), alice)
+			err := row.Scan(&got)
+			if err != pgx.ErrNoRows {
+				t.Errorf("fail-closed violated: want pgx.ErrNoRows, got %v (id=%s)", err, got)
+			}
+			return nil // don't propagate; the assertion is above
+		})
+		if err != nil {
+			t.Fatalf("tx: %v", err)
+		}
+	})
+
+	t.Run("given no user context is set/when any row is read/then zero rows return", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		defer tx.Rollback(ctx) //nolint:errcheck
+
+		var got uuid.UUID
+		row := tx.QueryRow(ctx,
+			fmt.Sprintf("SELECT id FROM %s WHERE id = $1", table), alice)
+		err = row.Scan(&got)
+		if err != pgx.ErrNoRows {
+			t.Errorf("fail-closed violated: want pgx.ErrNoRows, got %v (id=%s)", err, got)
+		}
+	})
+}

--- a/pkg/pgxdb/pool.go
+++ b/pkg/pgxdb/pool.go
@@ -1,0 +1,40 @@
+// Package pgxdb provides a pgx connection pool and a fail-closed
+// row-level-security (RLS) transaction helper.
+//
+// # Fail-closed RLS pattern
+//
+// Policies should be written so that an absent or empty GUC matches no rows:
+//
+//	USING (id = NULLIF(current_setting('app.current_user_id', true), '')::uuid)
+//
+// The NULLIF is essential because set_config with the third argument true
+// (transaction-local) reverts the GUC to its pre-transaction value when the
+// transaction ends — not to NULL, but to the empty string on a pooled
+// connection that has never had the GUC set at the session level. Without
+// NULLIF the empty string would be cast to a zero UUID and silently match
+// rows, defeating RLS. With NULLIF, '' folds to NULL and the comparison
+// returns NULL (not true), so no rows are visible — the policy is
+// fail-closed.
+package pgxdb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// NewPool creates a pgxpool.Pool from dsn and verifies connectivity with a
+// Ping. If the ping fails the pool is closed before the error is returned, so
+// callers never receive a pool in a broken state.
+func NewPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("pgxdb: new pool: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("pgxdb: ping: %w", err)
+	}
+	return pool, nil
+}

--- a/pkg/pgxdb/rls.go
+++ b/pkg/pgxdb/rls.go
@@ -1,0 +1,70 @@
+package pgxdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const defaultGUC = "app.current_user_id"
+
+// RLS runs queries inside transactions scoped to a user via a session GUC,
+// implementing the fail-closed row-level-security pattern. See the package
+// documentation for the required policy shape. Construct via NewRLS; the zero
+// value is not usable.
+type RLS struct {
+	pool *pgxpool.Pool
+	guc  string
+}
+
+// RLSOption configures an RLS instance.
+type RLSOption func(*RLS)
+
+// WithGUC overrides the session variable name used to convey the current user
+// identity to RLS policies. The default is "app.current_user_id".
+func WithGUC(name string) RLSOption {
+	return func(r *RLS) {
+		r.guc = name
+	}
+}
+
+// NewRLS constructs an RLS using the given pool and options.
+func NewRLS(pool *pgxpool.Pool, opts ...RLSOption) *RLS {
+	r := &RLS{pool: pool, guc: defaultGUC}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// InUserTx begins a transaction, sets the GUC transaction-locally via a
+// parameterized set_config call (SET LOCAL cannot accept bind parameters),
+// invokes fn, and commits. Any error — including one returned by fn — causes
+// a rollback. The GUC is set with the third argument to set_config as true so
+// it is scoped to the transaction and reverts automatically on commit or
+// rollback; see the package documentation for the NULLIF policy gotcha.
+func (r *RLS) InUserTx(ctx context.Context, userID uuid.UUID, fn func(pgx.Tx) error) error {
+	if r.pool == nil {
+		return errors.New("pgxdb: nil pool — construct RLS via NewRLS with a live pool")
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("pgxdb: begin: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if _, err := tx.Exec(ctx,
+		"SELECT set_config($1, $2, true)",
+		r.guc, userID.String(),
+	); err != nil {
+		return fmt.Errorf("pgxdb: set user context: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}


### PR DESCRIPTION
Adds the pgx-generation infrastructure packages, additively (no existing package touched):

- **`pkg/pgxdb`** — `NewPool` (close-on-ping-fail) and `RLS.InUserTx`: transactions scoped to a user via a configurable GUC (`WithGUC`, default `app.current_user_id`), implementing the fail-closed row-level-security pattern. Package docs cover the NULLIF policy shape and the pooled-connection empty-string GUC gotcha (found via CI on bygul).
- **`pkg/envelope`** — ADR-012-style envelope encryption: `KEKProvider` (env-var implementation, 32-byte base64 KEK), `FieldCipher` (AES-256-GCM, 32-byte DEK enforced, nonce-prepended), with **AAD as a first-class option** (`WithAAD`) threading into the AEAD.

Ported and generalized from CI-proven bygul code (sousair/bygul#6); bygul rewires to consume these once merged. Tests: 10 envelope subtests green; pgxdb integration tests are dual-skip on `GOCORE_PGX_TEST_DSN` and self-contained (temp table + FORCE RLS + cleanup).

Linear: [AIJ-101](https://linear.app/sousair/issue/AIJ-101/core-infra-slice-bygul-monorepo-walking-skeleton-memory-022-on-the)
