### PR TITLE
fix(jwt): wire token expiration, migrate to golang-jwt/v5 (AIJ-111)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,15 @@ go 1.25.1
 
 require (
 	github.com/cucumber/godog v0.15.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/cucumber/messages/go/v21 v21.0.1
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/go-redsync/redsync/v4 v4.15.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.25.1
+	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/redis/go-redis/v9 v9.17.2
 	github.com/stretchr/testify v1.11.1
@@ -23,7 +25,6 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
-	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
@@ -39,7 +40,6 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/cucumber/messages/go/v22 v22.0.0/go.mod h1:aZipXTKc0JnjCsXrJnuZpWhtay
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -42,6 +40,8 @@ github.com/go-redsync/redsync/v4 v4.15.0/go.mod h1:qNp+lLs3vkfZbtA/aM/OjlZHfEr5Y
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
 github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/gomodule/redigo v1.9.3 h1:dNPSXeXv6HCq2jdyWfjgmhBdqnR6PRO3m/G05nvpPC8=
 github.com/gomodule/redigo v1.9.3/go.mod h1:KsU3hiK/Ay8U42qpaJk+kuNa3C+spxapWpM+ywhcgtw=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/pkg/jwt/factory.go
+++ b/pkg/jwt/factory.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 )
 
 type (
@@ -14,14 +14,13 @@ type (
 	}
 
 	tokenPayload[T any] struct {
-		jwtgo.StandardClaims
+		jwtv5.RegisteredClaims
 		Payload *T `json:"payload"`
 	}
 )
 
 type jwt[T any] struct {
-	secret []byte
-	// TODO: Put this on a option of Generate Method
+	secret         []byte
 	expirationInMs int
 }
 
@@ -31,15 +30,16 @@ var ErrInvalidToken = errors.New("invalid token")
 
 func New[T any](secret string, expirationInMs int) JWT[T] {
 	return &jwt[T]{
-		secret: []byte(secret),
+		secret:         []byte(secret),
+		expirationInMs: expirationInMs,
 	}
 }
 
 func (j *jwt[T]) Generate(payload *T) (string, error) {
-	token := jwtgo.NewWithClaims(jwtgo.SigningMethodHS256, tokenPayload[T]{
+	token := jwtv5.NewWithClaims(jwtv5.SigningMethodHS256, tokenPayload[T]{
 		Payload: payload,
-		StandardClaims: jwtgo.StandardClaims{
-			ExpiresAt: jwtgo.TimeFunc().Add(time.Millisecond * time.Duration(j.expirationInMs)).Unix(),
+		RegisteredClaims: jwtv5.RegisteredClaims{
+			ExpiresAt: jwtv5.NewNumericDate(time.Now().Add(time.Duration(j.expirationInMs) * time.Millisecond)),
 		},
 	})
 
@@ -49,14 +49,10 @@ func (j *jwt[T]) Generate(payload *T) (string, error) {
 func (j *jwt[T]) Validate(token string) (*T, error) {
 	claims := &tokenPayload[T]{}
 
-	t, err := jwtgo.ParseWithClaims(token, claims, func(token *jwtgo.Token) (any, error) {
+	t, err := jwtv5.ParseWithClaims(token, claims, func(token *jwtv5.Token) (any, error) {
 		return j.secret, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if !t.Valid {
+	}, jwtv5.WithValidMethods([]string{"HS256"}))
+	if err != nil || !t.Valid {
 		return nil, ErrInvalidToken
 	}
 


### PR DESCRIPTION
Fix two defects in gocore pkg/jwt found during a downstream security review (bygul auth slice, AIJ-109):

1. **Tokens expired on issue.** `New(secret, expirationInMs)` never assigned `expirationInMs` to the struct, so `Generate` set `ExpiresAt = now + 0ms`. Consumers minting auth tokens got tokens with no meaningful expiry window. `New` now stores the value.
2. **Abandoned JWT library.** Migrated `github.com/dgrijalva/jwt-go` (archived, alg=none CVE lineage) → `github.com/golang-jwt/jwt/v5`. `StandardClaims` → `RegisteredClaims`; `Validate` now pins `WithValidMethods(["HS256"])` to prevent alg-confusion attacks; all parse errors map to the existing `ErrInvalidToken` sentinel.

Public interface unchanged (`JWT[T]`, `New`, `Generate`, `Validate`, `ErrInvalidToken`) — consumers need no change beyond a version bump.

Adds `pkg/jwt/factory_test.go` (build tag `unit`): valid round-trip, already-expired → `ErrInvalidToken` (this asserts the expiry fix), wrong-secret → error, garbage → error.

Linear: AIJ-111
